### PR TITLE
fix bug when no searchbar present

### DIFF
--- a/_theme_dev/src/js/theme/index.js
+++ b/_theme_dev/src/js/theme/index.js
@@ -2,6 +2,10 @@ import SearchInput from './components/SearchInput';
 
 const init = () => {
   const searchInput = document.querySelector('.js-search-input');
+  if (!searchInput) {
+    return;
+  }
+  
   const getAjaxUrlFromElement = (el) => (el && el.length ? el.getAttribute('data-search-controller-url') : null);
   const ajaxUrl = getAjaxUrlFromElement(document.querySelector('[data-search-controller-url]'));
   const body = document.querySelector('body');


### PR DESCRIPTION
When no searchbar is present (e.g. during checkout on /order page) this error is thrown:
```
Uncaught TypeError: Cannot read properties of null (reading 'closest')
    at HTMLDocument.init (is_searchbar.js?v=d41d8cd98f00b204e9800998ecf8427e:6:35)
```

This fixes that issue.